### PR TITLE
docker: add default expose for 1024/udp to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM vaporio/python:3.8-slim
 
-RUN pip install snmpsim
+RUN pip install --no-cache-dir snmpsim
 
 # Ensure the snmpsim has access to the MIB data. Additionally, snmpsim variation
 # modules (like writecache) are installed off the search path, so copy to where
 # it will be found.
 COPY mibs /home/snmpsim/mibs
+
 RUN groupadd -r snmpsim && useradd -r -g snmpsim snmpsim \
  && mkdir -p /home/snmpsim/.snmpsim/variation \
  && cp -r /usr/local/snmpsim/variation/* /home/snmpsim/.snmpsim/variation \
@@ -13,6 +14,8 @@ RUN groupadd -r snmpsim && useradd -r -g snmpsim snmpsim \
 
 WORKDIR /home/snmpsim
 USER snmpsim
+
+EXPOSE 1024/udp
 
 ENTRYPOINT ["snmpsimd.py"]
 CMD ["--help"]


### PR DESCRIPTION
This  PR:
- adds a default expose to the image
- disables pip caching, reducing image size by about 15MB