### PR TITLE
docker: update dockerfile so the image works in CI environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
 FROM vaporio/python:3.8-slim
 
-RUN pip install --no-cache-dir snmpsim
+RUN pip install --no-cache-dir -I snmpsim
 
-# Ensure the snmpsim has access to the MIB data. Additionally, snmpsim variation
-# modules (like writecache) are installed off the search path, so copy to where
-# it will be found.
-COPY mibs /home/snmpsim/mibs
+# The emulator needs to be run as a non-root user. The snmpsim variation
+# modules (like writecache) are installed off the search path, so copy them
+# to where they can be found. It seems like snmpsim gets installed with some
+# basic MIBs as well - these are removed from the image since their existence
+# appears to interfere with the proper loading and usage of the .snmpwalk files
+# that we define for the emulator.
+RUN groupadd -r snmp && useradd -r -g snmp snmp \
+ && mkdir -p /home/snmp/.snmpsim/variation \
+ && cp -r /usr/local/snmpsim/variation/* /home/snmp/.snmpsim/variation \
+ && rm -rf /usr/local/snmpsim/data \
+ && chown -R snmp:snmp /home/snmp
 
-RUN groupadd -r snmpsim && useradd -r -g snmpsim snmpsim \
- && mkdir -p /home/snmpsim/.snmpsim/variation \
- && cp -r /usr/local/snmpsim/variation/* /home/snmpsim/.snmpsim/variation \
- && chown -R snmpsim:snmpsim /home/snmpsim
+COPY . /home/snmp
 
-WORKDIR /home/snmpsim
-USER snmpsim
+WORKDIR /home/snmp
+USER snmp
 
 EXPOSE 1024/udp
 
-ENTRYPOINT ["snmpsimd.py"]
-CMD ["--help"]
+ENTRYPOINT ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -14,64 +14,31 @@ docker pull vaporio/snmp-emulator
 
 ## Running
 
-Running a container with no arguments will print out the help info:
-
-```console
-$ docker run vaporio/snmp-emulator
-Synopsis:
-  SNMP Agents Simulation tool. Responds to SNMP requests, variate responses
-  based on transport addresses, SNMP community name or SNMPv3 context name.
-  Can implement highly complex behavior through variation modules.
-Documentation:
-  http://snmplabs.com/snmpsim/simulating-agents.html
-Usage: /usr/local/bin/snmpsimd.py [--help]
-    [--version ]
-    [--debug=<io|dsp|msgproc|secmod|mibbuild|mibinstrum|acl|proxy|app|all>]
-    [--debug-asn1=<none|encoder|decoder|all>]
-    [--daemonize]
-    [--process-user=<uname>] [--process-group=<gname>]
-    [--pid-file=<file>]
-    [--logging-method=<syslog|file|stdout|stderr|null[:args>]>]
-    [--log-level=<debug|info|error>]
-    [--cache-dir=<dir>]
-    [--variation-modules-dir=<dir>]
-    [--variation-module-options=<module[=alias][:args]>]
-    [--force-index-rebuild]
-    [--validate-data]
-    [--args-from-file=<file>]
-    [--transport-id-offset=<number>]
-    [--v2c-arch]
-    [--v3-only]
-    [--v3-engine-id=<hexvalue>]
-    [--v3-context-engine-id=<hexvalue>]
-    [--v3-user=<username>]
-    [--v3-auth-key=<key>]
-    [--v3-auth-proto=<MD5|SHA|SHA224|SHA256|SHA384|SHA512>]
-    [--v3-priv-key=<key>]
-    [--v3-priv-proto=<3DES|AES|AES128|AES192|AES192BLMT|AES256|AES256BLMT|DES>]
-    [--data-dir=<dir>]
-    [--max-varbinds=<number>]
-    [--agent-udpv4-endpoint=<X.X.X.X:NNNNN>]
-    [--agent-udpv6-endpoint=<[X:X:..X]:NNNNN>]
-    [--agent-unix-endpoint=</path/to/named/pipe>]
+`snmpsim` is run within the container via the [`run.sh`](run.sh) script. It provides some lightweight
+initial context logging and then kicks off the simulator with the following arguments:
 
 ```
-
-Pass in your desired configuration via these flags. You can select which MIB to use
-by setting the `--data-dir` option. The snmpwalks defined in the [`mibs/`](mibs/) subdirectory
-are mounted into the container at `/home/snmpsim/mibs`. The image working directory is
-`/home/snmpsim`, so to specify the UPS MIB (along with some SNMPv3 config), for example:
-
-```
-$ docker run vaporio/snmp-emulator \
-    --data-dir=mibs/ups \
-    --agent-udpv4-endpoint=0.0.0.0:1024 \
-    --v3-user=simulator \
-    --v3-auth-key=auctoritas \
-    --v3-auth-proto=SHA \
-    --v3-priv-key=privatus \
-    --v3-priv-proto=AES
+--data-dir="$1"
+--agent-udpv4-endpoint=0.0.0.0:1024
+--v3-user=simulator
+--v3-auth-key=auctoritas
+--v3-auth-proto=SHA
+--v3-priv-key=privatus
+--v3-priv-proto=AES
 ```
 
-Note that the agent endpoint should always use the host `0.0.0.0` in order for the container
+Currently, the snmp-emulator does not support customizing these configuration options, so ensure any
+setup which uses the emulator adheres to the configuration specified above.
+
+The `--data-dir` argument takes a value passed to the container. This should be the relative path to the
+MIB (or, more specifically, .snmpwalk file) that you want to load. The currently supported MIBs are found
+in the [`mibs`](mibs) subdirectory.
+
+To configure the emulator to run with the UPS MIB, for example:
+
+```
+$ docker run vaporio/snmp-emulator mibs/ups
+```
+
+Note that the agent endpoint always uses the host `0.0.0.0` in order for the container
 to properly expose the endpoint.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# run.sh
+#
+# Run the SNMP emulator. This takes one argument - the path of the MIB to
+# load and use, e.g. './run.sh mibs/ups'
+#
+
+echo "Starting SNMP Emulator"
+
+echo "Arguments:"
+for i in "$@"; do
+  echo "- $i"
+done
+
+echo "Available MIBs:"
+for name in mibs/*; do
+  echo "- ${name}"
+done
+echo "-----------------------------"
+
+python "$(command -v snmpsimd.py)" \
+    --data-dir="$1" \
+    --agent-udpv4-endpoint=0.0.0.0:1024 \
+    --v3-user=simulator \
+    --v3-auth-key=auctoritas \
+    --v3-auth-proto=SHA \
+    --v3-priv-key=privatus \
+    --v3-priv-proto=AES \
+    2>&1


### PR DESCRIPTION
This PR:
- updates the docker image to fix the underlying issue with why it wasn't working in CI integration tests. I'm still not totally clear what was happening, but the short of it is that for some reason, this version of snmpsim shipped with some default mibs/snmpwalk configs which were installed  in /usr/local and when run locally via docker-compose, our  custom snmpwalk was being used (which is what we want), but when run in CI K8s, something about the setup was causing it to use one of the built-in defaults.

  hence the errors looking like the mib was missing data/incorrectly defined - because the built-in one didn't have the data at the expected OIDs. removing the default stuff that was installed seems to have fixed the CI run issues.

-  I also added a run.sh to wrap the execution of the emulator. this is in part because many of the arguments will remain the same across our uses, so this simplifies things. It also adds a little bit of contextual "logging" at the beginning of execution which can be helpful.

fixes #1

~In  the morning, I need to update the project README as part of this PR~